### PR TITLE
Add 1.16 to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-bypass.md
+++ b/.github/ISSUE_TEMPLATE/report-bypass.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Troubleshooting Information
 `Change - [ ] to - [X] to check the checkboxes below.`
 - [ ] Matrix and ProtocolLib are up-to-date
-- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15 server
+- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15, or 1.16 server
 - [ ] The issue happens on default config.yml and checks.yml
 - [ ] I've tested if the issue happens on default config
 

--- a/.github/ISSUE_TEMPLATE/report-console-error.md
+++ b/.github/ISSUE_TEMPLATE/report-console-error.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Troubleshooting Information
 `Change - [ ] to - [X] to check the checkboxes below.`
 - [ ] Matrix and ProtocolLib are up-to-date
-- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, or 1.15 server
+- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15, or 1.16 server
 - [ ] The issue happens on default config.yml and checks.yml
 - [ ] I've tested if the issue happens on default config
 

--- a/.github/ISSUE_TEMPLATE/report-false-positives.md
+++ b/.github/ISSUE_TEMPLATE/report-false-positives.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Troubleshooting Information
 `Change - [ ] to - [X] to check the checkboxes below.`
 - [ ] Matrix and ProtocolLib are up-to-date
-- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15 server
+- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15, or 1.16 server
 - [ ] The issue happens on default config.yml and checks.yml
 - [ ] I've tested if the issue happens on default config
 

--- a/.github/ISSUE_TEMPLATE/report-plugin-incompatibility.md
+++ b/.github/ISSUE_TEMPLATE/report-plugin-incompatibility.md
@@ -11,7 +11,7 @@ assignees: ''
 `Change - [ ] to - [X] to check the checkboxes below.`
 - [ ] The incompatible plugin is up-to-date
 - [ ] Matrix and ProtocolLib are up-to-date
-- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, or 1.15 server
+- [ ] Matrix is running on a 1.8, 1.12, 1.13, 1.14, 1.15, or 1.16 server
 - [ ] The issue happens on default config.yml and checks.yml
 - [ ] I've tested if the issue happens on default config
 


### PR DESCRIPTION
A *massive* change, adds `1.16` to the `Matrix is running on a ... server` checkbox. (resolves #2198)